### PR TITLE
Update Victron status based on solar and SOC

### DIFF
--- a/alfen_driver/logic.py
+++ b/alfen_driver/logic.py
@@ -443,8 +443,10 @@ def get_victron_min_soc() -> float:
         bus = dbus.SystemBus()
         settings = bus.get_object("com.victronenergy.settings", "/")
         settings_values = settings.GetValue()
+        # Prefer SocLimit if available, fallback to MinimumSocLimit for compatibility
         min_soc = settings_values.get(
-            "Settings/CGwacs/BatteryLife/MinimumSocLimit", 10.0
+            "Settings/CGwacs/BatteryLife/SocLimit",
+            settings_values.get("Settings/CGwacs/BatteryLife/MinimumSocLimit", 10.0),
         )
         return float(min_soc)
     except Exception:


### PR DESCRIPTION
Implement WAIT_SUN and LOW_SOC Victron statuses in AUTO mode to reflect insufficient solar or low battery SoC.

---
<a href="https://cursor.com/background-agent?bcId=bc-213a63eb-0619-4986-a501-6ae602d8573d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-213a63eb-0619-4986-a501-6ae602d8573d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

