### PR TITLE
Investigate VRM firmware update timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Integrate an Alfen Eve (Pro Line and similar NG9xx platform) EV charger with a V
 
 See `requirements.txt` and `requirements-dev.txt`.
 
+Note for GX devices: Run the driver in a dedicated Python virtual environment and avoid installing requirements into the system Python. The built‑in two‑way communication service expects an older `pymodbus` and may break if system packages are upgraded. Keep system packages untouched; install this project's deps only inside the venv.
+
 ## Quick start (local testing)
 
 1) Clone and enter the repo
@@ -82,20 +84,26 @@ git clone https://github.com/yourusername/victron-alfen-charger.git
 cd victron-alfen-charger
 cp alfen_driver_config.sample.yaml alfen_driver_config.yaml
 vi alfen_driver_config.yaml   # set modbus.ip and other fields as needed
-pip3 install -r requirements.txt
 chmod +x main.py
 ```
 
-4) Test run
+4) Create a dedicated virtual environment and install dependencies (recommended)
 
 ```bash
-./main.py
+python3 -m venv /data/alfen-venv
+/data/alfen-venv/bin/pip install -r requirements.txt
 ```
 
-5) Auto‑start on boot (rc.local)
+5) Test run
 
 ```bash
-echo '/data/victron-alfen-charger/main.py &' >> /data/rc.local
+/data/alfen-venv/bin/python ./main.py
+```
+
+6) Auto‑start on boot (rc.local)
+
+```bash
+echo '/data/alfen-venv/bin/python /data/victron-alfen-charger/main.py &' >> /data/rc.local
 chmod +x /data/rc.local
 ```
 

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -422,6 +422,15 @@ modbus:
   ip: "192.168.1.100"
 ```
 
+### 1a. Use a virtual environment on GX (recommended)
+On Venus OS devices (e.g., Cerbo GX), create a dedicated Python virtual environment for this project to avoid modifying system packages used by built‑in services. Example:
+```bash
+python3 -m venv /data/alfen-venv
+/data/alfen-venv/bin/pip install -r /data/victron-alfen-charger/requirements.txt
+# Run the driver
+/data/alfen-venv/bin/python /data/victron-alfen-charger/main.py
+```
+
 ### 2. Use Configuration Validation
 Always validate configuration before deployment:
 ```bash


### PR DESCRIPTION
Update documentation to recommend using a Python virtual environment on GX devices to prevent dependency conflicts with system services.

The `mqtt-rpc` service on GX devices relies on `pymodbus` v2. Installing the Alfen driver's `pymodbus` v3 dependency directly into the system Python environment causes `mqtt-rpc` to crash, leading to the VRM firmware update page timing out. A virtual environment isolates the driver's dependencies, ensuring system services remain functional.

---
<a href="https://cursor.com/background-agent?bcId=bc-86ece427-c866-4fb1-93e0-57b801ab0493">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-86ece427-c866-4fb1-93e0-57b801ab0493">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

