### PR TITLE
Update charging current display

### DIFF
--- a/alfen_driver/driver.py
+++ b/alfen_driver/driver.py
@@ -157,6 +157,7 @@ class AlfenDriver:
             "product_name": "Alfen EV Charger",
             "device_instance": int(self.config.device_instance),
             "session": {},
+            "applied_current": float(self.intended_set_current.value),
         }
 
         self.logger.info("Driver initialization complete")
@@ -428,6 +429,11 @@ class AlfenDriver:
 
             log_msg += f". Reason: {explanation}"
             self.logger.info(log_msg)
+            # Reflect the applied current in the HTTP snapshot for the UI
+            try:
+                self._merge_status_snapshot({"applied_current": float(effective_current)})
+            except Exception:
+                pass
             return True
         else:
             self.logger.warning(f"Failed to apply current on {source}")
@@ -830,6 +836,9 @@ class AlfenDriver:
             snapshot["serial"] = str(self.service.get("/Serial", ""))
             snapshot["product_name"] = str(self.service.get("/ProductName", ""))
             snapshot["device_instance"] = int(self.config.device_instance)
+            
+            # Maintain last applied current for UI display logic
+            snapshot["applied_current"] = float(self.last_sent_current)
 
             if (
                 hasattr(self.session_manager, "current_session")

--- a/alfen_driver/driver.py
+++ b/alfen_driver/driver.py
@@ -431,9 +431,13 @@ class AlfenDriver:
             self.logger.info(log_msg)
             # Reflect the applied current in the HTTP snapshot for the UI
             try:
-                self._merge_status_snapshot({"applied_current": float(effective_current)})
-            except Exception:
-                pass
+                self._merge_status_snapshot(
+                    {"applied_current": float(effective_current)}
+                )
+            except Exception as exc:
+                self.logger.debug(
+                    f"Failed to update applied_current in snapshot: {exc}"
+                )
             return True
         else:
             self.logger.warning(f"Failed to apply current on {source}")
@@ -836,7 +840,7 @@ class AlfenDriver:
             snapshot["serial"] = str(self.service.get("/Serial", ""))
             snapshot["product_name"] = str(self.service.get("/ProductName", ""))
             snapshot["device_instance"] = int(self.config.device_instance)
-            
+
             # Maintain last applied current for UI display logic
             snapshot["applied_current"] = float(self.last_sent_current)
 

--- a/alfen_driver/webui/app.js
+++ b/alfen_driver/webui/app.js
@@ -363,18 +363,18 @@ async function fetchStatus() {
     setChargeUI(Number(s.start_stop ?? 1) === 1);
     // Determine which current to display based on mode
     const mode = Number(s.mode ?? 0);
-    let displayCurrent = Number(s.set_current ?? 6.0);
+    const setpoint = Number(s.set_current ?? 6.0);
+    let displayCurrent = setpoint;
     if (mode === 1) { // AUTO
-      displayCurrent = Number(s.applied_current ?? s.set_current ?? 0);
+      displayCurrent = Number(s.applied_current ?? setpoint);
     } else if (mode === 2) { // SCHEDULED
-      displayCurrent = Number(s.applied_current ?? s.set_current ?? 0);
+      displayCurrent = Number(s.applied_current ?? setpoint);
     }
     // Update display and slider separately
     const stationMax = Number(s.station_max_current ?? 0);
     setCurrentUI(displayCurrent, stationMax);
     const slider = $('current_slider');
-    if (slider) {
-      const setpoint = Number(s.set_current ?? 6.0);
+    if (slider && Date.now() >= currentDirtyUntil) {
       slider.value = String(setpoint);
       slider.setAttribute('aria-valuenow', String(Math.round(setpoint)));
     }

--- a/alfen_driver/webui/app.js
+++ b/alfen_driver/webui/app.js
@@ -29,8 +29,14 @@ const chartHistory = {
 function addHistoryPoint(s) {
   const t = Date.now() / 1000;
   const current = Number(s.ac_current || 0);
-  const allowed = Number(s.set_current || 0);
+  let allowed = Number(s.set_current || 0);
   const station = Number(s.station_max_current || 0);
+  const mode = Number(s.mode || 0);
+  if (mode === 1) { // AUTO
+    allowed = Number(s.applied_current ?? allowed);
+  } else if (mode === 2) { // SCHEDULED
+    allowed = Number(s.applied_current ?? allowed);
+  }
   chartHistory.points.push({ t, current, allowed, station });
   const cutoff = t - chartHistory.windowSec;
   chartHistory.points = chartHistory.points.filter(p => p.t >= cutoff);
@@ -171,16 +177,14 @@ function setChargeUI(enabled) {
   }
 }
 
-function setCurrentUI(amps, stationMax) {
+function setCurrentUI(displayAmps, stationMax) {
   if (Date.now() < currentDirtyUntil) {
     return;
   }
   const slider = $('current_slider');
-  slider.value = String(amps);
-  slider.setAttribute('aria-valuenow', String(Math.round(amps)));
-  $('current_display').textContent = `${Math.round(amps)} A`;
+  $('current_display').textContent = `${Math.round(displayAmps)} A`;
   // Update slider min/max based on station capabilities
-  if (stationMax > 0) {
+  if (slider && stationMax > 0) {
     const max = Math.min(stationMax, 25);
     slider.max = String(max);
     slider.setAttribute('aria-valuemax', String(max));
@@ -357,7 +361,23 @@ async function fetchStatus() {
     setTextIfExists('firmware', s.firmware ? `FW ${s.firmware}` : '');
     setModeUI(Number(s.mode ?? 0));
     setChargeUI(Number(s.start_stop ?? 1) === 1);
-    setCurrentUI(Number(s.set_current ?? 6.0), Number(s.station_max_current ?? 0));
+    // Determine which current to display based on mode
+    const mode = Number(s.mode ?? 0);
+    let displayCurrent = Number(s.set_current ?? 6.0);
+    if (mode === 1) { // AUTO
+      displayCurrent = Number(s.applied_current ?? s.set_current ?? 0);
+    } else if (mode === 2) { // SCHEDULED
+      displayCurrent = Number(s.applied_current ?? s.set_current ?? 0);
+    }
+    // Update display and slider separately
+    const stationMax = Number(s.station_max_current ?? 0);
+    setCurrentUI(displayCurrent, stationMax);
+    const slider = $('current_slider');
+    if (slider) {
+      const setpoint = Number(s.set_current ?? 6.0);
+      slider.value = String(setpoint);
+      slider.setAttribute('aria-valuenow', String(Math.round(setpoint)));
+    }
     setTextIfExists('di', s.device_instance ?? '');
     const stName = statusNames[s.status] || '-';
     setTextIfExists('status', stName);


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Updates the web UI to display "Charging Current" based on the operating mode and introduces `applied_current` to the backend API.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This change ensures the "Charging Current" display provides more relevant real-time feedback: showing the user-configured current in MANUAL mode, and the actual applied current in AUTO and SCHEDULED modes. The slider continues to control the `set_current` setpoint.

---
<a href="https://cursor.com/background-agent?bcId=bc-4f3a145e-ff23-4be2-acc5-f852ec33ab97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4f3a145e-ff23-4be2-acc5-f852ec33ab97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

